### PR TITLE
Change BreakWhole to accept element by value

### DIFF
--- a/src/elements/break_whole.rs
+++ b/src/elements/break_whole.rs
@@ -1,8 +1,8 @@
 use crate::*;
 
-pub struct BreakWhole<'a, E: Element>(pub &'a E);
+pub struct BreakWhole<E: Element>(pub E);
 
-impl<'a, E: Element> Element for BreakWhole<'a, E> {
+impl<E: Element> Element for BreakWhole<E> {
     fn first_location_usage(&self, ctx: FirstLocationUsageCtx) -> FirstLocationUsage {
         let layout = self.layout(
             ctx.text_pieces_cache,
@@ -122,7 +122,7 @@ enum Layout {
     },
 }
 
-impl<'a, E: Element> BreakWhole<'a, E> {
+impl<E: Element> BreakWhole<E> {
     fn layout(
         &self,
         text_pieces_cache: &TextPiecesCache,
@@ -159,9 +159,12 @@ impl<'a, E: Element> BreakWhole<'a, E> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{
-        record_passes::{Break, BreakableDraw, DrawPass, RecordPasses},
-        *,
+    use crate::{
+        elements::ref_element::RefElement,
+        test_utils::{
+            record_passes::{Break, BreakableDraw, DrawPass, RecordPasses},
+            *,
+        },
     };
 
     #[test]
@@ -180,7 +183,7 @@ mod tests {
                 width: 3.,
             });
 
-            let element = BreakWhole(&content);
+            let element = BreakWhole(RefElement(&content));
 
             let ret = callback.call(element);
 
@@ -234,7 +237,7 @@ mod tests {
                 width: 3.,
             });
 
-            let element = BreakWhole(&content);
+            let element = BreakWhole(RefElement(&content));
 
             let ret = callback.call(element);
 
@@ -297,7 +300,7 @@ mod tests {
                 width: 3.,
             });
 
-            let element = BreakWhole(&content);
+            let element = BreakWhole(RefElement(&content));
 
             let ret = callback.call(element);
 
@@ -360,7 +363,7 @@ mod tests {
                 width: 3.,
             });
 
-            let element = BreakWhole(&content);
+            let element = BreakWhole(RefElement(&content));
 
             let ret = callback.call(element);
 

--- a/src/serde_elements/elements.rs
+++ b/src/serde_elements/elements.rs
@@ -709,7 +709,7 @@ impl<E: SerdeElement> SerdeElement for BreakWhole<E> {
         fonts: &impl for<'a> Index<&'a str, Output = Font>,
         callback: impl CompositeElementCallback,
     ) {
-        callback.call(&elements::break_whole::BreakWhole(&SerdeElementElement {
+        callback.call(&elements::break_whole::BreakWhole(SerdeElementElement {
             element: &*self.element,
             fonts,
         }));


### PR DESCRIPTION
We made the same change to other elements at some point, but this seems to have been missed.

Taking a reference makes it impossible to return an `impl Element` from a function in a lot of cases and there isn't really a good reason why it should be a reference. For the rare cases where a reference is needed `RefElement` can be used. But this tends to only be relevant for testing.